### PR TITLE
Ignore encoding errors when opening scb files

### DIFF
--- a/events2dolphin.py
+++ b/events2dolphin.py
@@ -101,7 +101,7 @@ def parse_scb(path: str) -> List[Event]:
     Returns:
       An Event corresponding to the start list file
     """
-    scb = open(path, "r")
+    scb = open(path, "r", encoding="utf-8", errors="ignore")
     lines = scb.readlines()
     scb.close()
     if (len(lines)-1) % 10:


### PR DESCRIPTION
Hi, thanks for creating this, its been very useful.

This pull request handles a case I encountered with windows-1252 encoded swimmer names in the .scb files causing the process to fail.  Since we don't actually care about the swimmer names we can just ignore encoding errors when opening the scb file.